### PR TITLE
Fix typo in object User property plan.

### DIFF
--- a/Chapter02/src/components/User.vue
+++ b/Chapter02/src/components/User.vue
@@ -7,7 +7,7 @@
       </li>
       <li>username: {{userData.login}}</li>
       <li>followers: {{userData.followers}}</li>
-      <li>plan: {{userData.pla && userData.plan.name}}</li>
+      <li>plan: {{userData.plan && userData.plan.name}}</li>
     </ul>
   </div>
 </template>


### PR DESCRIPTION
Correct property name is plan https://docs.github.com/en/rest/reference/users